### PR TITLE
Update extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "ms-python.vscode-pylance",
         "esbenp.prettier-vscode",
         "wayou.vscode-todo-highlight",
-        "bungcip.better-toml"
+        "bungcip.better-toml",
+        "charliermarsh.ruff",
     ]
 }


### PR DESCRIPTION
on cookiecutter, vscode will now recommend the user installs the `ruff` extension. This harmonises the extensions.json with the settings.json